### PR TITLE
feat: Normalize area_id before lookup

### DIFF
--- a/src/roborock-vacuum-card.ts
+++ b/src/roborock-vacuum-card.ts
@@ -391,6 +391,7 @@ export class RoborockVacuumCard extends LitElement {
       return areas;
 
     for (let { area_id, roborock_area_id } of this.config.areas) {
+      area_id = area_id.replace(/ /g, '_').toLowerCase();
       const area = this.hass.areas[area_id];
       if (!area)
           continue;


### PR DESCRIPTION
This change makes the card more robust by normalizing the `area_id` provided in the configuration. It converts the `area_id` to lowercase and replaces spaces with underscores before using it to look up the area in Home Assistant.

This fixes an issue where areas would not appear on the card if the `area_id` in the configuration did not exactly match the Home Assistant area ID format (e.g., using "Living room" instead of "living_room").